### PR TITLE
chore: bump resonate-sdk floor to >=0.6.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Cully Wakelin", email = "flossypurse@gmail.com" }
 ]
 dependencies = [
-    "resonate-sdk>=0.6.3",
+    "resonate-sdk>=0.6.7",
     "flask>=3.0.3",
     "selenium>=4.26.1",
     "bs4>=0.0.2",


### PR DESCRIPTION
## Summary

Standardizes the `resonate-sdk` pin across the Python example repos. Audit found the lower-bound spread across the org included 0.4.8, 0.5.0, 0.5.1, 0.5.3, 0.5.4, 0.6.1, 0.6.2, 0.6.3, and 0.6.4 — sloppy and not great for reproducibility. Latest published SDK on PyPI is 0.6.7.

This bumps the floor to `>=0.6.7` for parity with the rest of the Python example repos. SemVer-wise it still satisfies the same range; resolvers were just being given more slack than they needed.

Part of a coordinated sweep across ~21 Python example repos.

## Test plan

- [ ] `uv sync` (or `pip install -e .`) resolves cleanly with the new floor
- [ ] Example still runs (no API surface used that's pre-0.6.7)